### PR TITLE
Mass rebalance prototype

### DIFF
--- a/data/naltok outfits.txt
+++ b/data/naltok outfits.txt
@@ -161,7 +161,7 @@ outfit `"Agama" Ion Thruster`
 	"mass" 10
 	"outfit space" -10
 	"engine capacity" -10
-	"thrust" 6.84
+	"thrust" 13.68
 	"thrusting energy" .25
 	"thrusting heat" .25
 	"flare sprite" "effect/naltok flare/tiny"
@@ -176,7 +176,7 @@ outfit `"Anole" Ion Thruster`
 	"mass" 19
 	"outfit space" -19
 	"engine capacity" -19
-	"thrust" 13.78
+	"thrust" 27.56
 	"thrusting energy" .45
 	"thrusting heat" .5
 	"flare sprite" "effect/naltok flare/small"
@@ -191,7 +191,7 @@ outfit `"Gecko" Ion Thruster`
 	"mass" 34
 	"outfit space" -34
 	"engine capacity" -34
-	"thrust" 25.9
+	"thrust" 51.8
 	"thrusting energy" .75
 	"thrusting heat" .8
 	"flare sprite" "effect/naltok flare/medium"
@@ -206,7 +206,7 @@ outfit `"Iguana" Ion Thruster`
 	"mass" 61
 	"outfit space" -61
 	"engine capacity" -61
-	"thrust" 48.95
+	"thrust" 97.9
 	"thrusting energy" 1.35
 	"thrusting heat" 1.4
 	"flare sprite" "effect/naltok flare/large"
@@ -221,7 +221,7 @@ outfit `"Monitor" Ion Thruster`
 	"mass" 97
 	"outfit space" -97
 	"engine capacity" -97
-	"thrust" 81.34
+	"thrust" 162.68
 	"thrusting energy" 1.85
 	"thrusting heat" 2.16
 	"flare sprite" "effect/naltok flare/huge"
@@ -236,7 +236,7 @@ outfit `"Agama" Ion Steering`
 	"mass" 14
 	"outfit space" -14
 	"engine capacity" -14
-	"turn" 341.8
+	"turn" 683.6
 	"turning energy" .35
 	"turning heat" .4
 	"steering flare sprite" "effect/naltok flare/tiny"
@@ -251,7 +251,7 @@ outfit `"Anole" Ion Steering`
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25
-	"turn" 644.9
+	"turn" 1289.8
 	"turning energy" .55
 	"turning heat" .7
 	"steering flare sprite" "effect/naltok flare/small"
@@ -266,7 +266,7 @@ outfit `"Gecko" Ion Steering`
 	"mass" 43
 	"outfit space" -43
 	"engine capacity" -43
-	"turn" 1245.55
+	"turn" 2491.1
 	"turning energy" .9
 	"turning heat" 1.1
 	"steering flare sprite" "effect/naltok flare/medium"
@@ -281,7 +281,7 @@ outfit `"Iguana" Ion Steering`
 	"mass" 73
 	"outfit space" -73
 	"engine capacity" -73
-	"turn" 2351.4
+	"turn" 4702.8
 	"turning energy" 1.5
 	"turning heat" 1.8
 	"steering flare sprite" "effect/naltok flare/large"
@@ -296,7 +296,7 @@ outfit `"Monitor" Ion Steering`
 	"mass" 115
 	"outfit space" -115
 	"engine capacity" -115
-	"turn" 4091.6
+	"turn" 8183.2
 	"turning energy" 2.07
 	"turning heat" 2.61
 	"steering flare sprite" "effect/naltok flare/huge"
@@ -313,7 +313,7 @@ outfit `"Wyrm" Afterburner`
 	"mass" 24
 	"outfit space" -24
 	"engine capacity" -24
-	"afterburner thrust" 68
+	"afterburner thrust" 136
 	"afterburner fuel" .03
 	"afterburner energy" 1.4
 	"afterburner heat" 2.15

--- a/data/naltok ships.txt
+++ b/data/naltok ships.txt
@@ -22,8 +22,8 @@ ship "Mackerel"
 		"hull heat" .375
 		"required crew" 4
 		"bunks" 29
-		"mass" 256
-		"drag" 3.1
+		"mass" 512
+		"drag" 4.6
 		"heat dissipation" .155
 		"fuel capacity" 700
 		"cargo space" 38
@@ -68,8 +68,8 @@ ship "Marlin"
 		"hull heat" .825
 		"required crew" 32
 		"bunks" 152
-		"mass" 640
-		"drag" 6.3
+		"mass" 1708
+		"drag" 12.6
 		"heat dissipation" .115
 		"fuel capacity" 600
 		"cargo space" 64
@@ -118,8 +118,8 @@ ship "Sturgeon"
 		"hull heat" 2.175
 		"required crew" 43
 		"bunks" 313
-		"mass" 880
-		"drag" 9.2
+		"mass" 3434
+		"drag" 24
 		"heat dissipation" .085
 		"fuel capacity" 500
 		"cargo space" 368
@@ -171,8 +171,8 @@ ship "Herring"
 		"hull heat" .1875
 		"required crew" 2
 		"bunks" 3
-		"mass" 128
-		"drag" 1.8
+		"mass" 228
+		"drag" 2.5
 		"heat dissipation" .145
 		"fuel capacity" 400
 		"cargo space" 92
@@ -233,8 +233,8 @@ ship "Conger"
 		"hull heat" .45
 		"required crew" 4
 		"bunks" 5
-		"mass" 320
-		"drag" 4.3
+		"mass" 788
+		"drag" 7.7
 		"heat dissipation" .12
 		"fuel capacity" 600
 		"cargo space" 242
@@ -289,8 +289,8 @@ ship "Flounder"
 		"hull heat" .9
 		"required crew" 12
 		"bunks" 17
-		"mass" 1280
-		"drag" 13.7
+		"mass" 3072
+		"drag" 27.4
 		"heat dissipation" .055
 		"fuel capacity" 600
 		"cargo space" 864
@@ -342,8 +342,8 @@ ship "Grouper"
 		"hull heat" 1.5375
 		"required crew" 15 
 		"bunks" 27
-		"mass" 960
-		"drag" 9.8
+		"mass" 1920
+		"drag" 19.6
 		"heat dissipation" .095
 		"fuel capacity" 4000
 		"cargo space" 64

--- a/data/naltok ships.txt
+++ b/data/naltok ships.txt
@@ -397,8 +397,8 @@ ship "Guppy"
 		"hull heat" .6
 		"required crew" 1
 		"bunks" 3
-		"mass" 104
-		"drag" 1.7
+		"mass" 162
+		"drag" 2.05
 		"heat dissipation" .225
 		"fuel capacity" 500
 		"cargo space" 36
@@ -443,8 +443,8 @@ ship "Tetra"
 		"hull heat" .7125
 		"required crew" 1
 		"bunks" 2
-		"mass" 128
-		"drag" 1.6
+		"mass" 266
+		"drag" 2.25
 		"heat dissipation" .215
 		"fuel capacity" 400
 		"cargo space" 6
@@ -502,8 +502,8 @@ ship "Archerfish"
 		"hull heat" .825
 		"required crew" 3
 		"bunks" 5
-		"mass" 200
-		"drag" 2.25
+		"mass" 408
+		"drag" 3.2
 		"heat dissipation" .205
 		"fuel capacity" 300
 		"cargo space" 8
@@ -550,8 +550,8 @@ ship "Piranha"
 		"hull heat" 1.2
 		"required crew" 5
 		"bunks" 11
-		"mass" 400
-		"drag" 3.8
+		"mass" 932
+		"drag" 6.4
 		"heat dissipation" .19
 		"fuel capacity" 600
 		"cargo space" 64
@@ -684,8 +684,8 @@ ship "Barracuda"
 		"hull heat" 1.725
 		"required crew" 7
 		"bunks" 24
-		"mass" 448
-		"drag" 4.6
+		"mass" 1152
+		"drag" 8.3
 		"heat dissipation" .175
 		"fuel capacity" 600
 		"cargo space" 72
@@ -747,8 +747,8 @@ ship "Albacore"
 		"hull heat" 1.575
 		"required crew" 12
 		"bunks" 18
-		"mass" 512
-		"drag" 6.2
+		"mass" 1432
+		"drag" 12.4
 		"heat dissipation" .16
 		"fuel capacity" 700
 		"cargo space" 12
@@ -806,8 +806,8 @@ ship "Moray"
 		"hull heat" 2.1
 		"required crew" 22
 		"bunks" 42
-		"mass" 624
-		"drag" 6.3
+		"mass" 2016
+		"drag" 13.9
 		"heat dissipation" .13
 		"fuel capacity" 400
 		"cargo space" 128
@@ -864,8 +864,8 @@ ship "Pike"
 		"hull heat" 2.325
 		"required crew" 42
 		"bunks" 56
-		"mass" 960
-		"drag" 10.3
+		"mass" 3435
+		"drag" 24.7
 		"heat dissipation" .1
 		"fuel capacity" 600
 		"cargo space" 216
@@ -954,8 +954,8 @@ ship "Mola"
 		"hull heat" 2.175
 		"required crew" 56
 		"bunks" 68
-		"mass" 1536
-		"drag" 15.2
+		"mass" 5654.4
+		"drag" 42.5
 		"heat dissipation" .085
 		"fuel capacity" 400
 		"cargo space" 24
@@ -1031,8 +1031,8 @@ ship "Kaluga"
 		"hull heat" 2.925
 		"required crew" 72
 		"bunks" 80
-		"mass" 1664
-		"drag" 14.4
+		"mass" 6864
+		"drag" 43.2
 		"heat dissipation" .075
 		"fuel capacity" 400
 		"cargo space" 0
@@ -1138,8 +1138,8 @@ ship "Remora"
 		"hull heat" .45
 		"required crew" 1
 		"bunks" 1
-		"mass" 56
-		"drag" .76
+		"mass" 72
+		"drag" .84
 		"heat dissipation" .225
 		"outfit space" 112
 		"weapon capacity" 28


### PR DESCRIPTION
Prototype for a rebalancing of mass and handling. For now, this is just a test thing with the Naltok, but I could extend this to a PR to the main ES repo covering all ships.

Changes are as follows:

**All engines x2 thrust&turn**
This is just to give more room to buff small ships, without hull masses going negative.

**Mass and Drag increased by varying amounts across the board:**
Fighters: mostly unchanged, x1.1 for very large fighters (the Remora in this PR, and probably the Petrel and Heliarch Stalker)
This means most fighters have double the top speed, double the turning, and double the acceleration, while very large fighters get slightly less than double.

Interceptors: on average x1.2 mass and drag (varying from x1.1 for small, fast interceptors like the Sparrow and Wasp to x1.4 for very large interceptors like the Hawk, Merganser and Tetra) 
This gives interceptors a range from +80% to +40% to speed, turn and acceleration.

LWs on average x1.6 mass and drag (varying from x1.4 for Quicksilver and Summer Leaf to x1.8 for Gunboat and MPT53)
Resulting range approx +40% to +10%.

MWs on average x2 mass and drag (varying from x1.8 for Splinter & Manta to x2.2 for Bastion and Bulwark)
Range from +10% to -10%. On average, MWs handle as they did before, though smaller ones slightly better and larger ones slightly worse.

HWs on average x2.6 mass and drag (varying from x2.2 for Vanguard and Protector to x3 for Carrier & KIV) 
Range from -10% to -33%. This is where the nerf is.
The Vanguard, which is barely out of the category of MW, and the Protector, which is already painfully slow and not particularly large, receive the smallest nerfs, while larger HWs lose up to a third of their top speed, acceleration and turning.

**Non-combat classes:**
Drone - always no change
LF - as LW (similar sizes, and wouldn't make sense to make different changes between the mod argosy and the regular one)
HF - as MW (Heavy Freighters do not need their speed nerfed further, so I'm content to leave their mobility as is rather than nerfing them like HWs.)
SL - as MW (Space Liners are fine as is, on the whole.)
Utility - case by case, probably ranging from as MW to as HW (Mule, for example, is like a MW, Bactrian and Rano'erek are more like large HWs)
Superheavy - more than HW (they are bigger)
Transport - case by case, probably ranging from as interceptor to as LW (Shuttle, for example, is like a small interceptor, Blackbird is more like a medium LW).

For this PR, the changes are:
Mackerel: x1.5
Marlin: x2
Sturgeon: x2.6
Herring: x1.4
Conger: x1.8
Flounder: x2
Grouper: x2
Guppy: x1.2
Tetra: x1.4
Archerfish: x1.4
Piranha: x1.7
Barracuda: x1.8
Albacore: x2
Moray: x2.2
Pike: x2.4
Mola: x2.9
Kaluga: x3
Remora: x1.1
Lamprey: no change
Minnow: no change
